### PR TITLE
Mark packed struct with `aligned` attribute to silence linker warnings

### DIFF
--- a/TestXSmallTest-iOS/AppDelegate.m
+++ b/TestXSmallTest-iOS/AppDelegate.m
@@ -12,10 +12,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    // Override point for customization after application launch.
-    self.window.backgroundColor = [UIColor whiteColor];
-    [self.window makeKeyAndVisible];
+//    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+//    // Override point for customization after application launch.
+//    self.window.backgroundColor = [UIColor whiteColor];
+//    [self.window makeKeyAndVisible];
     return YES;
 }
 

--- a/XSmallTest.h
+++ b/XSmallTest.h
@@ -157,7 +157,7 @@ static const int XSM_TEST_PARENT_RESERVED_ __attribute__((unused)) = __COUNTER__
 struct int_xsm_sect_record_record_ ## __xsm_tag ## _t { \
     int_xsm_section_record record; \
     char description[sizeof(__xsm_description)]; \
-} __attribute__((packed)); \
+} __attribute__((packed, aligned)); \
 \
 static struct int_xsm_sect_record_record_ ## __xsm_tag ## _t int_xsm_sect_record_record_ ## __xsm_tag __attribute__((section(XSM_SEG_NAME "," XSM_SECT_NAME))) __attribute__((used)) = { \
     .record = { \


### PR DESCRIPTION
Also, disable window initialization in the test app to work around unrelated crash (so that tests can proceed).